### PR TITLE
correct bad import in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ pip install pycamt
 You can create an instance of the Camt053Parser by providing the XML data as a string:
 
 ```python
-from Camt053Parser import Camt053Parser
+from pycamt.parser import Camt053Parser
 
 xml_data = "<Document>...</Document>"  # Your CAMT.053 XML data as a string
 parser = Camt053Parser(xml_data)


### PR DESCRIPTION
Modified the package name in the README.me file to reflect the actual package name which is pycamt.parser.Camt053Parser